### PR TITLE
Add new formats to allowed_extensions

### DIFF
--- a/src/google_photos_upload/filefinder.py
+++ b/src/google_photos_upload/filefinder.py
@@ -1,7 +1,11 @@
 import os
 
 class FileFinder:
-    def __init__(self, path, allowed_extensions = [ 'jpg', 'jpeg', 'png', 'gif', 'avi', 'mov', 'mp4', '3gp', 'm4v', 'bmp', 'm2ts']) -> None:
+    def __init__(self, path, allowed_extensions = [
+        'jpg', 'jpeg', 'png', 'gif', 'avi', 'mov', 'mp4', '3gp', 'm4v', 'bmp', 'm2ts', 
+        'avif', 'heic', 'ico', 'tiff', 'webp', 'raw', '3g2', 'asf', 'divx', 'm2t', 'mkv', 
+        'mmv', 'mod', 'mpg', 'mts', 'tod', 'wmv'
+    ]) -> None:
         if not os.path.isdir(path):
             print("\nERROR: {} is not a directory.".format(path))
             exit(1)


### PR DESCRIPTION
Update `allowed_extensions` list in `filefinder.py` to include new photo and video formats.

* Add new photo formats: 'avif', 'heic', 'ico', 'tiff', 'webp', 'raw'
* Add new video formats: '3g2', 'asf', 'divx', 'm2t', 'mkv', 'mmv', 'mod', 'mpg', 'mts', 'tod', 'wmv'
* Format the `allowed_extensions` list to multiple lines for better readability

https://developers.google.com/photos/library/guides/upload-media